### PR TITLE
Add current and voltage feed forward terms to motor classes

### DIFF
--- a/src/common/base_classes/FOCMotor.h
+++ b/src/common/base_classes/FOCMotor.h
@@ -172,6 +172,8 @@ class FOCMotor
     float voltage_bemf; //!< estimated backemf voltage (if provided KV constant)
     float	Ualpha, Ubeta; //!< Phase voltages U alpha and U beta used for inverse Park and Clarke transform
 
+    DQCurrent_s feed_forward_current;//!< current d and q current measured
+    DQVoltage_s feed_forward_voltage;//!< current d and q voltage set to the motor
 
     // motor configuration parameters
     float voltage_sensor_align;//!< sensor and motor align voltage parameter


### PR DESCRIPTION
This change adds feed forward terms for the voltage and current controllers. This allows including inputs using system parameters and knowledge not available to the PID controllers to improve performance. 

Some examples of use cases might be using the moving inertia with an S-curve motion profile to calculate the torque (current) required to follow the profile. Without feed forward, following error depends solely on the PID controller, with feed forward the PID controller is only responsible for compensating unmodeled disturbances. Another example would be using a motor to resist a known load, like gravity, or a spring, while in angle or velocity control mode. This currently would depend on the PID controller to compensate for the load, but because the load is well known it can be calculated directly. The response of the system to predicable changes in this load no longer depends on the PID controller bandwidth.

This change still needs testing, but I wanted to get it out there while I had a chance. :)