### PR TITLE
ESP32C3 fix ledc_channel_config(847): sleep_mode argument invalid

### DIFF
--- a/src/drivers/hardware_specific/esp32/esp32_ledc_mcu.cpp
+++ b/src/drivers/hardware_specific/esp32/esp32_ledc_mcu.cpp
@@ -104,6 +104,7 @@ bool _ledcAttachChannelAdvanced(uint8_t pin, int _channel, int _group, uint32_t 
   uint32_t duty = ledc_get_duty(group, channel);
   ledc_channel_config_t ledc_channel;
   ledc_channel.speed_mode = group;
+  ledc_channel.sleep_mode = LEDC_SLEEP_MODE_KEEP_ALIVE;
   ledc_channel.channel =  channel;
   ledc_channel.timer_sel = LEDC_TIMER_0; 
   ledc_channel.intr_type = LEDC_INTR_DISABLE;


### PR DESCRIPTION
Hi, quick PR here. 

This was the only way I was able to make this board work -> https://www.espboards.dev/esp32/esp32-c3-super-mini-plus/

No matter which pins I used, I was intermittently 3 out of 5 boots getting the following error:

```
EP32-DRV: Configuring 3PWM
EP32-DRV: 3PWM setup in group: 0
E (290) ledc: ledc_channel_config(847): sleep_mode argument is invalid
EP32-DRV: ERROR - Failed to attach channel:0
EP32-DRV: ERROR - Failed to configure pin:1
```

This PR fixes it. I don't know if this is a good solution, but works bulletproof for the C3 board in quesiton.

Open to discuss. Thanks.