### PR TITLE
Make Init, Enable, Disable and setPWM of drivers virtual

### DIFF
--- a/src/drivers/BLDCDriver3PWM.h
+++ b/src/drivers/BLDCDriver3PWM.h
@@ -25,11 +25,11 @@ class BLDCDriver3PWM: public BLDCDriver
     BLDCDriver3PWM(int phA,int phB,int phC, int en1 = NOT_SET, int en2 = NOT_SET, int en3 = NOT_SET);
     
     /**  Motor hardware init function */
-  	int init() override;
+  	virtual int init() override;
     /** Motor disable function */
-  	void disable() override;
+  	virtual void disable() override;
     /** Motor enable function */
-    void enable() override;
+    virtual void enable() override;
 
     // hardware variables
   	int pwmA; //!< phase A pwm pin number
@@ -46,7 +46,7 @@ class BLDCDriver3PWM: public BLDCDriver
      * @param Ub - phase B voltage
      * @param Uc - phase C voltage
     */
-    void setPwm(float Ua, float Ub, float Uc) override;
+    virtual void setPwm(float Ua, float Ub, float Uc) override;
 
     /** 
      * Set phase voltages to the hardware

--- a/src/drivers/BLDCDriver6PWM.h
+++ b/src/drivers/BLDCDriver6PWM.h
@@ -26,11 +26,11 @@ class BLDCDriver6PWM: public BLDCDriver
     BLDCDriver6PWM(int phA_h,int phA_l,int phB_h,int phB_l,int phC_h,int phC_l, int en = NOT_SET);
     
     /**  Motor hardware init function */
-  	int init() override;
+  	virtual int init() override;
     /** Motor disable function */
-  	void disable() override;
+  	virtual void disable() override;
     /** Motor enable function */
-    void enable() override;
+    virtual void enable() override;
 
     // hardware variables
   	int pwmA_h,pwmA_l; //!< phase A pwm pin number
@@ -50,7 +50,7 @@ class BLDCDriver6PWM: public BLDCDriver
      * @param Ub - phase B voltage
      * @param Uc - phase C voltage
     */
-    void setPwm(float Ua, float Ub, float Uc) override;
+    virtual void setPwm(float Ua, float Ub, float Uc) override;
 
     /** 
      * Set phase voltages to the harware 

--- a/src/drivers/StepperDriver2PWM.h
+++ b/src/drivers/StepperDriver2PWM.h
@@ -36,11 +36,11 @@ class StepperDriver2PWM: public StepperDriver
     StepperDriver2PWM(int pwm1, int dir1, int pwm2, int dir2, int en1 = NOT_SET, int en2 = NOT_SET);
 
     /**  Motor hardware init function */
-  	int init() override;
+  	virtual int init() override;
     /** Motor disable function */
-  	void disable() override;
+  	virtual void disable() override;
     /** Motor enable function */
-    void enable() override;
+    virtual void enable() override;
 
     // hardware variables
     int pwm1; //!< phase 1 pwm pin number
@@ -58,7 +58,7 @@ class StepperDriver2PWM: public StepperDriver
      * @param Ua phase A voltage
      * @param Ub phase B voltage
     */
-    void setPwm(float Ua, float Ub) override;
+    virtual void setPwm(float Ua, float Ub) override;
 
     /** 
      * Set phase voltages to the hardware

--- a/src/drivers/StepperDriver4PWM.h
+++ b/src/drivers/StepperDriver4PWM.h
@@ -25,11 +25,11 @@ class StepperDriver4PWM: public StepperDriver
     StepperDriver4PWM(int ph1A,int ph1B,int ph2A,int ph2B, int en1 = NOT_SET, int en2 = NOT_SET);
     
     /**  Motor hardware init function */
-  	int init() override;
+  	virtual int init() override;
     /** Motor disable function */
-  	void disable() override;
+  	virtual void disable() override;
     /** Motor enable function */
-    void enable() override;
+    virtual void enable() override;
 
     // hardware variables
   	int pwm1A; //!< phase 1A pwm pin number
@@ -45,7 +45,7 @@ class StepperDriver4PWM: public StepperDriver
      * @param Ua phase A voltage
      * @param Ub phase B voltage
     */
-    void setPwm(float Ua, float Ub) override;
+    virtual void setPwm(float Ua, float Ub) override;
 
 
     /** 


### PR DESCRIPTION
This add the Virtual keyword to functions defined in BLDC6PWM, BLDC3PWM, Stepper2PWM, and Stepper4PWM, so that they can be overloaded further down the line with a call back to the original functionnality.

Use case for this is in the instance of the STSPIN32G4: Bootstrap capacitors need to be charged before any high level output can be requested to avoid triggering Vds protection by high side UVLO. 

This is done by enabling the low side mosfets for a time (as described in the datasheet). Overloading the Enable functions allows for that to be done when needed, instead of all the time, as enabling the low side mosfets effectively brakes the motor.

The base class, FOCDriver, already has them virtual, so this adds no extra cost/vtable complexity.
