### PR TITLE
Feat allow spi clock speed change

### DIFF
--- a/src/sensors/MagneticSensorSPI.cpp
+++ b/src/sensors/MagneticSensorSPI.cpp
@@ -50,7 +50,7 @@ MagneticSensorSPIConfig_s MA730_SPI = {
 //  cs              - SPI chip select pin
 //  _bit_resolution   sensor resolution bit number
 // _angle_register  - (optional) angle read register - default 0x3FFF
-MagneticSensorSPI::MagneticSensorSPI(int cs, int _bit_resolution, int _angle_register){
+MagneticSensorSPI::MagneticSensorSPI(int cs, int _bit_resolution, int _angle_register, long _clock_speed){
 
   chip_select_pin = cs;
   // angle read register of the magnetic sensor
@@ -58,7 +58,7 @@ MagneticSensorSPI::MagneticSensorSPI(int cs, int _bit_resolution, int _angle_reg
   // register maximum value (counts per revolution)
   cpr = _powtwo(_bit_resolution);
   spi_mode = SPI_MODE1;
-  clock_speed = 1000000;
+  clock_speed = _isset(_clock_speed) ? _clock_speed : 1000000; 
   bit_resolution = _bit_resolution;
 
   command_parity_bit = 15; // for backwards compatibilty
@@ -66,14 +66,16 @@ MagneticSensorSPI::MagneticSensorSPI(int cs, int _bit_resolution, int _angle_reg
   data_start_bit = 13; // for backwards compatibilty
 }
 
-MagneticSensorSPI::MagneticSensorSPI(MagneticSensorSPIConfig_s config, int cs){
+MagneticSensorSPI::MagneticSensorSPI(MagneticSensorSPIConfig_s config, int cs, long _clock_speed){
   chip_select_pin = cs;
   // angle read register of the magnetic sensor
   angle_register = config.angle_register ? config.angle_register : DEF_ANGLE_REGISTER;
   // register maximum value (counts per revolution)
   cpr = _powtwo(config.bit_resolution);
   spi_mode = config.spi_mode;
-  clock_speed = config.clock_speed;
+  // allow to override clock speed from config with the one provided as argument
+  // if the argument clock speed is not provided (i.e. is NOT_SET), use the clock speed from the config
+  clock_speed = _isset(_clock_speed) ? _clock_speed : config.clock_speed;
   bit_resolution = config.bit_resolution;
 
   command_parity_bit = config.command_parity_bit; // for backwards compatibilty

--- a/src/sensors/MagneticSensorSPI.h
+++ b/src/sensors/MagneticSensorSPI.h
@@ -29,14 +29,19 @@ class MagneticSensorSPI: public Sensor{
      * @param cs  SPI chip select pin 
      * @param bit_resolution   sensor resolution bit number
      * @param angle_register  (optional) angle read register - default 0x3FFF
+     * @param clock_speed  (optional) SPI clock speed
      */
-    MagneticSensorSPI(int cs, int bit_resolution, int angle_register = 0);
+    MagneticSensorSPI(int cs, int bit_resolution, int angle_register = 0, long clock_speed = NOT_SET);
+
+     /**
+     *  MagneticSensorSPI class constructor
     /**
      *  MagneticSensorSPI class constructor
      * @param config   SPI config
      * @param cs  SPI chip select pin
+     * @param clock_speed  (optional) SPI clock speed
      */
-    MagneticSensorSPI(MagneticSensorSPIConfig_s config, int cs);
+    MagneticSensorSPI(MagneticSensorSPIConfig_s config, int cs, long clock_speed = NOT_SET);
 
     /** sensor initialise pins */
     void init(SPIClass* _spi = &SPI);


### PR DESCRIPTION
At the moment we usually run the SPI sensors at 1MHz which is in many cases a lot under sensor capabilities. 

Till now, we did allow changing it through the `sensor.clock_speed` variable or through the `MagneticSensorSPIConfig_s`.

But for the sake of simplicity this PR adds the posibility too. 
It's backwards compatible, no changes in the API - the parameter is optional. 


Example usage - running AS5048 at 5mHz
```cpp
MagneticSensorSPI sensor = MagneticSensorSPI(AS5048_SPI, D4, 5000000);
```

Example usage - running AS5047 at 5mHz
```cpp
MagneticSensorSPI sensor = MagneticSensorSPI(D4, 14, 0x3FFF, 5000000); // using default AS5047 config
```

