### PR TITLE
Fix for issue #518 absoluteZeroSearch not moving the motor to seek for the encoder zero

### DIFF
--- a/src/common/base_classes/FOCMotor.cpp
+++ b/src/common/base_classes/FOCMotor.cpp
@@ -937,11 +937,14 @@ int FOCMotor::absoluteZeroSearch() {
   velocity_limit = velocity_index_search;
   voltage_limit = voltage_sensor_align;
   shaft_angle = 0;
-  while(sensor->needsSearch() && shaft_angle < _2PI){
-    angleOpenloop(1.5f*_2PI);
+  // TODO: Try the dedicated method for converting mec and elec angles
+  while(sensor->needsSearch() && shaft_angle < pole_pairs*_2PI){
+    angleOpenloop(pole_pairs*1.5f*_2PI);
     // call important for some sensors not to loose count
     // not needed for the search
     sensor->update();
+    // set the voltage to the motor
+    setPhaseVoltage(voltage_limit, 0, shaft_angle);
   }
   // disable motor
   setPhaseVoltage(0, 0, 0);

--- a/src/common/base_classes/FOCMotor.cpp
+++ b/src/common/base_classes/FOCMotor.cpp
@@ -937,8 +937,8 @@ int FOCMotor::absoluteZeroSearch() {
   velocity_limit = velocity_index_search;
   voltage_limit = voltage_sensor_align;
   shaft_angle = 0;
-  // TODO: Try the dedicated method for converting mec and elec angles
-  float search_rotation_target = _electricalAngle(1.5f*_2PI, pole_pairs)
+  // calculting elctrical angle equivalent for a 1.5 mechanical rotation
+  float search_rotation_target = _electricalAngle(1.5f*_2PI, pole_pairs);
   while(sensor->needsSearch() && shaft_angle < search_rotation_target){
     angleOpenloop(search_rotation_target);
     // call important for some sensors not to loose count

--- a/src/common/base_classes/FOCMotor.cpp
+++ b/src/common/base_classes/FOCMotor.cpp
@@ -938,8 +938,9 @@ int FOCMotor::absoluteZeroSearch() {
   voltage_limit = voltage_sensor_align;
   shaft_angle = 0;
   // TODO: Try the dedicated method for converting mec and elec angles
-  while(sensor->needsSearch() && shaft_angle < pole_pairs*_2PI){
-    angleOpenloop(pole_pairs*1.5f*_2PI);
+  float search_rotation_target = _electricalAngle(1.5f*_2PI, pole_pairs)
+  while(sensor->needsSearch() && shaft_angle < search_rotation_target){
+    angleOpenloop(search_rotation_target);
     // call important for some sensors not to loose count
     // not needed for the search
     sensor->update();


### PR DESCRIPTION
# Description

Fix for issue #518 absoluteZeroSearch not moving the motor to seek for the encoder zero.

# Tests
Tested on my motor setup:
- 1000KV motor
- 1000ppm ABI Encoder
- B-G431B-ESC1 board

I've repeated the initialization sequence from various starting angles, always got a successful zero from the encoder.

