### PR TITLE
foc_utils: Fix unintended double conversion.

### DIFF
--- a/src/common/foc_utils.cpp
+++ b/src/common/foc_utils.cpp
@@ -75,7 +75,7 @@ __attribute__((weak)) float _atan2(float y, float x) {
 
 // normalizing radian angle to [0,2PI]
 __attribute__((weak)) float _normalizeAngle(float angle){
-  float a = fmod(angle, _2PI);
+  float a = fmodf(angle, _2PI);
   return a >= 0 ? a : (a + _2PI);
 }
 


### PR DESCRIPTION
# Description

`fmod` takes a double and returns a double, which requires two conversions that are expensive on many MCUs.  fmodf is the correct function to call here.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Compilation only.
