### PR TITLE
MagneticSensorAnalog: Fix angle calculation

### DIFF
--- a/src/sensors/MagneticSensorAnalog.cpp
+++ b/src/sensors/MagneticSensorAnalog.cpp
@@ -9,7 +9,7 @@ MagneticSensorAnalog::MagneticSensorAnalog(uint8_t _pinAnalog, int _min_raw_coun
 
   pinAnalog = _pinAnalog;
 
-  cpr = _max_raw_count - _min_raw_count;
+  cpr = _max_raw_count - _min_raw_count + 1;
   min_raw_count = _min_raw_count;
   max_raw_count = _max_raw_count;
 

--- a/src/sensors/MagneticSensorAnalog.cpp
+++ b/src/sensors/MagneticSensorAnalog.cpp
@@ -33,7 +33,7 @@ void MagneticSensorAnalog::init(){
 float MagneticSensorAnalog::getSensorAngle(){
   // raw data from the sensor
   raw_count = getRawCount();   
-  return ( (float) (raw_count) / (float)cpr) * _2PI;
+  return ( (float) (raw_count - min_raw_count) / (float)cpr) * _2PI;
 }
 
 // function reading the raw counter of the magnetic sensor


### PR DESCRIPTION
# Description

`MagneticSensorAnalog::getSensorAngle` has a slightly incorrect implementation for converting `raw_count` to degrees:

> `return ( (float) (raw_count) / (float)cpr) * _2PI;`

It should first subtract `min_raw_count` from `raw_count` so it is properly in the range `[0, cpr]` before dividing by `cpr`.

Also, the `cpr` calculation is slightly incorrect; it should be:\
`cpr = _min_raw_count - _max_raw_count + 1;`
Reasoning in comments below.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
^ Not sure which of the two it is. I'd expect it to only make things better due to more accurate position calculations, but hard to be sure somebody's current code doesn't somehow depend on the slightly incorrect original implementation.

# How Has This Been Tested?

Ran velocity control, which was working before my change, and worked after as well.

**Test Configuration/Setup**:
* Hardware:
  * SimpleFOC Mini
  * 2804 gimbal motor
  * AS5600 magnetic encoder (using analog OUT)
  * All from [this Amazon listing](https://www.amazon.com/dp/B0FXKN9YMJ)
* IDE: Arduino
* MCU package version: XIAO RP2040
