### PR TITLE
Improve sensor delta_angle calculation

### DIFF
--- a/src/common/base_classes/Sensor.cpp
+++ b/src/common/base_classes/Sensor.cpp
@@ -29,9 +29,11 @@ float Sensor::getVelocity() {
     }
     if (Ts < min_elapsed_time) return velocity; // don't update velocity if deltaT is too small
 
-    const float delta_angle =
-        (int32_t)(full_rotations - vel_full_rotations) * _2PI
-        + (angle_prev - vel_angle_prev);
+    float delta_angle = angle_prev - vel_angle_prev;
+    const int32_t delta_full_rotations = full_rotations - vel_full_rotations;
+    if (delta_full_rotations) {
+        delta_angle += delta_full_rotations * _2PI;
+    }
 
     // floating point equality checks are bad, so instead we check that the angle change is very small
     if (fabsf(delta_angle) > 1e-8f) {

--- a/src/common/base_classes/Sensor.cpp
+++ b/src/common/base_classes/Sensor.cpp
@@ -29,18 +29,9 @@ float Sensor::getVelocity() {
     }
     if (Ts < min_elapsed_time) return velocity; // don't update velocity if deltaT is too small
 
-    float current_angle = 0.0f;
-    float prev_angle = 0.0f;
-    // Avoid floating point precision loss for large full_rotations
-    // this is likely optional
-    if (full_rotations == vel_full_rotations) {
-        current_angle = angle_prev;
-        prev_angle = vel_angle_prev;
-    } else {
-        current_angle = (float) full_rotations * _2PI + angle_prev;
-        prev_angle = (float) vel_full_rotations * _2PI + vel_angle_prev;
-    }
-    const float delta_angle = current_angle - prev_angle;
+    const float delta_angle =
+        (int32_t)(full_rotations - vel_full_rotations) * _2PI
+        + (angle_prev - vel_angle_prev);
 
     // floating point equality checks are bad, so instead we check that the angle change is very small
     if (fabsf(delta_angle) > 1e-8f) {

--- a/src/common/base_classes/Sensor.cpp
+++ b/src/common/base_classes/Sensor.cpp
@@ -29,6 +29,8 @@ float Sensor::getVelocity() {
     }
     if (Ts < min_elapsed_time) return velocity; // don't update velocity if deltaT is too small
 
+    // Calculate change in angle. Handles `full_rotations` integer wrap-arounds,
+    // and avoids float precision loss issues by keeping numbers small.
     float delta_angle = angle_prev - vel_angle_prev;
     const int32_t delta_full_rotations = full_rotations - vel_full_rotations;
     if (delta_full_rotations) {


### PR DESCRIPTION
# Description

Improve `delta_angle` calculation in `Sensor::getVelocity()` by:
1. Handling `full_rotations` integer wrap-arounds.
2. Preventing float precision loss issues from unbounded float growth.
3. Fewer float ops --> faster.

Math explanation:
```cpp
// Current implementation
delta_angle = (full_rotations * 2pi + angle_prev) - (vel_full_rotations * 2pi + vel_angle_prev);
                           // ^ this op grows without bound; eventually not enough precision for angle_prev

// Proposed implementation
delta_angle = 2pi * (full_rotations - vel_full_rotations) + (angle_prev - vel_angle_prev);
               // ^ this op should always be small; the full_rotations delta will never be >1 under normal circumstances
```

**Comparing Floating Point Ops** (assuming other ops are basically free)
| Code Path | Current Code | Proposed Code |
|--------|--------|--------|
| Hot (rotations equal) | 1 fsub | 1 fsub |
| Cold (rotations differ) | **7 total:** 2 i2f, 2 fmul, 2 fadd, 1 fsub | **4 total:** 1 i2f, 1 fmul, 1 fadd, 1 fsub | 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Basically just put a motor on velocity control mode at 5RPS for a long time.

**Test Configuration/Setup**:
* Hardware:
  * SimpleFOC Mini
  * 2804 gimbal motor
  * AS5600 magnetic encoder (using analog OUT)
  * All from [this Amazon listing](https://www.amazon.com/dp/B0FXKN9YMJ)
* IDE: Arduino
* MCU package version: XIAO RP2040
