### PR TITLE
Add support for hal overloading on stm32g4, cleanup index to injected rank util

### DIFF
--- a/src/current_sense/hardware_specific/stm32/stm32_adc_utils.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32_adc_utils.cpp
@@ -417,29 +417,24 @@ uint32_t _getADCChannel(PinName pin, ADC_TypeDef *AdcHandle )
 
 uint32_t _getADCInjectedRank(uint8_t ind){
   switch (ind) {
-  #ifdef ADC_INJECTED_RANK_1
+#ifdef ADC_INJECTED_RANK_1
     case 0:
       return ADC_INJECTED_RANK_1;
-      break;
 #endif
 #ifdef ADC_INJECTED_RANK_2
     case 1:
       return ADC_INJECTED_RANK_2;
-      break;
 #endif
 #ifdef ADC_INJECTED_RANK_3
     case 2:
       return ADC_INJECTED_RANK_3;
-      break;
 #endif
 #ifdef ADC_INJECTED_RANK_4
     case 3:
       return ADC_INJECTED_RANK_4;
-      break;
 #endif
     default:
       return 0;
-      break;
   }
 }
 

--- a/src/current_sense/hardware_specific/stm32/stm32_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32_mcu.cpp
@@ -1,7 +1,7 @@
 
 #include "../../hardware_api.h"
 
-#if defined(_STM32_DEF_) and !defined(ARDUINO_B_G431B_ESC1) 
+#if defined(_STM32_DEF_) and !defined(ARDUINO_B_G431B_ESC1) && !defined(SIMPLEFOC_HAL_OVERRIDE)
 
 #include "stm32_mcu.h"
 

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.cpp
@@ -1,6 +1,6 @@
 #include "stm32g4_hal.h"
 
-#if defined(STM32G4xx) && !defined(ARDUINO_B_G431B_ESC1)
+#if defined(STM32G4xx) && !defined(ARDUINO_B_G431B_ESC1) && !defined(SIMPLEFOC_HAL_OVERRIDE)
 
 #include "../../../../communication/SimpleFOCDebug.h"
 

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.h
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.h
@@ -3,7 +3,7 @@
 
 #include "Arduino.h"
 
-#if defined(STM32G4xx) && !defined(ARDUINO_B_G431B_ESC1)
+#if defined(STM32G4xx) && !defined(ARDUINO_B_G431B_ESC1) && !defined(SIMPLEFOC_HAL_OVERRIDE)
 
 #include "stm32g4xx_hal.h"
 #include "../stm32_mcu.h"

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_mcu.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_mcu.cpp
@@ -1,6 +1,6 @@
 #include "../../../hardware_api.h"
 
-#if defined(STM32G4xx) && !defined(ARDUINO_B_G431B_ESC1)
+#if defined(STM32G4xx) && !defined(ARDUINO_B_G431B_ESC1) && !defined(SIMPLEFOC_HAL_OVERRIDE)
 
 #include "../../../../common/foc_utils.h"
 #include "../../../../drivers/hardware_api.h"


### PR DESCRIPTION
This allows for other boards to override the default HAL behaviour for current sense on G4 (Such as Phoque 1 and 2)

Also, index to injected rank : breaks aren't necessary when returning in a case.