### PR TITLE
Fix feedforward voltage initialization.

### DIFF
--- a/src/common/base_classes/FOCMotor.h
+++ b/src/common/base_classes/FOCMotor.h
@@ -220,8 +220,8 @@ class FOCMotor
     float voltage_bemf; //!< estimated backemf voltage (if provided KV constant)
     float	Ualpha, Ubeta; //!< Phase voltages U alpha and U beta used for inverse Park and Clarke transform
 
-    DQCurrent_s feed_forward_current;//!< current d and q current measured
-    DQVoltage_s feed_forward_voltage;//!< current d and q voltage set to the motor
+    DQCurrent_s feed_forward_current = {0.0f, 0.0f};//!< current d and q current measured
+    DQVoltage_s feed_forward_voltage = {0.0f, 0.0f};//!< current d and q voltage set to the motor
 
     // motor configuration parameters
     float voltage_sensor_align;//!< sensor and motor align voltage parameter


### PR DESCRIPTION
Resolves #522.

# Description

Initializes feedforward values to zero. These values could be anything otherwise.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Compilation only.