### PR TITLE
fix SIMPLEFOC_DISABLE_DEBUG, so that it works even without using the macro

### DIFF
--- a/src/communication/SimpleFOCDebug.cpp
+++ b/src/communication/SimpleFOCDebug.cpp
@@ -122,4 +122,14 @@ void SimpleFOCDebug::println() {
     }
 }
 
+void SimpleFOCDebug::printf(const char* msg, ...)
+{
+    va_list ap;
+    va_start(ap, msg);
+    if (_debugPrint != NULL) {
+        _debugPrint->vprintf(msg, ap);
+    }
+    va_end(ap);
+}
+
 #endif

--- a/src/communication/SimpleFOCDebug.h
+++ b/src/communication/SimpleFOCDebug.h
@@ -56,6 +56,8 @@ public:
     inline static void print(const StringSumHelper msg){}
     inline static void print(int val){}
     inline static void print(float val){}
+
+    static void printf(const char* msg, ...){}
 };
 
 #define SIMPLEFOC_DEBUG(msg, ...)
@@ -83,6 +85,8 @@ public:
     static void print(const StringSumHelper msg);
     static void print(int val);
     static void print(float val);
+
+    static void printf(const char* msg, ...);
 
 protected:
     static Print* _debugPrint;

--- a/src/communication/SimpleFOCDebug.h
+++ b/src/communication/SimpleFOCDebug.h
@@ -34,7 +34,33 @@
 
 // #define SIMPLEFOC_DISABLE_DEBUG
 
-#ifndef SIMPLEFOC_DISABLE_DEBUG 
+#ifdef SIMPLEFOC_DISABLE_DEBUG 
+class SimpleFOCDebug {
+public:
+    inline static void enable(Print* debugPrint){}
+
+    inline static void println(const __FlashStringHelper* msg){}
+    inline static void println(const StringSumHelper msg){}
+    inline static void println(const char* msg){}
+    inline static void println(const __FlashStringHelper* msg, float val){}
+    inline static void println(const char* msg, float val){}
+    inline static void println(const __FlashStringHelper* msg, int val){}
+    inline static void println(const char* msg, int val){}
+    inline static void println(const char* msg, char val){}
+    inline static void println(){}
+    inline static void println(int val){}
+    inline static void println(float val){}
+
+    inline static void print(const char* msg){}
+    inline static void print(const __FlashStringHelper* msg){}
+    inline static void print(const StringSumHelper msg){}
+    inline static void print(int val){}
+    inline static void print(float val){}
+};
+
+#define SIMPLEFOC_DEBUG(msg, ...)
+
+#else
 
 class SimpleFOCDebug {
 public:
@@ -65,11 +91,6 @@ protected:
 
 #define SIMPLEFOC_DEBUG(msg, ...) \
     SimpleFOCDebug::println(F(msg), ##__VA_ARGS__)
-
-#else  //ifndef SIMPLEFOC_DISABLE_DEBUG
- 
-#define SIMPLEFOC_DEBUG(msg, ...)
-
 
 #endif //ifndef SIMPLEFOC_DISABLE_DEBUG
 #endif


### PR DESCRIPTION
# Description

SIMPLEFOC_DISABLE_DEBUG doesn't work when using the drivers repository, because the class SimpleFOCDebug gets removed. 

This uses inlining to remove the debug instead, so using the macro isn't necessary.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Compiled and run on target.

**Test Configuration/Setup**:
* Hardware: Phoque2a
* IDE: Platformio
* MCU package version (stm32duino/arduino-esp32/..) : Not relevant