### PR TITLE
stm32: do not declare ADC interrupts unless using SIMPLEFOC_STM32_ADC_INTERRUPT

### DIFF
--- a/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32f1/stm32f1_hal.cpp
@@ -190,7 +190,7 @@ int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int
   return 0;
 }
 
-
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void ADC1_2_IRQHandler(void)
   {
@@ -207,5 +207,6 @@ extern "C" {
   }
 #endif
 }
+#endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32g4/stm32g4_hal.cpp
@@ -246,7 +246,7 @@ int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int
   return 0;
 }
 
-
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void ADC1_2_IRQHandler(void)
   {
@@ -279,4 +279,5 @@ extern "C" {
   }
 #endif
 }
+#endif
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32h7/stm32h7_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32h7/stm32h7_hal.cpp
@@ -227,7 +227,7 @@ int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int
   return 0;
 }
 
-
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void ADC_IRQHandler(void)
   {
@@ -246,6 +246,7 @@ extern "C" {
       HAL_ADC_IRQHandler(&hadc[2]);
   }
 }
+#endif
 #endif
 
 #endif

--- a/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_hal.cpp
+++ b/src/current_sense/hardware_specific/stm32/stm32l4/stm32l4_hal.cpp
@@ -245,6 +245,7 @@ int _adc_gpio_init(Stm32CurrentSenseParams* cs_params, const int pinA, const int
   return 0;
 }
 
+#ifdef SIMPLEFOC_STM32_ADC_INTERRUPT
 extern "C" {
   void ADC1_2_IRQHandler(void)
   {
@@ -277,5 +278,6 @@ extern "C" {
   }
 #endif
 }
+#endif
 
 #endif


### PR DESCRIPTION
This allows the user to declare their own ADC interrupts when they're not in use by SimpleFOC (which they're not by default)