### PR TITLE
Fix typo in KV rating comment in BLDCMotor.cpp

### DIFF
--- a/src/BLDCMotor.cpp
+++ b/src/BLDCMotor.cpp
@@ -33,7 +33,7 @@ int trap_150_map[12][3] = {
 // BLDCMotor( int pp , float R)
 // - pp            - pole pair number
 // - R             - motor phase resistance
-// - KV            - motor kv rating (rmp/v)
+// - KV            - motor kv rating (rpm/V)
 // - Lq            - motor q-axis inductance [H]
 // - Ld            - motor d-axis inductance [H]
 BLDCMotor::BLDCMotor(int pp, float _R, float _KV, float _Lq, float _Ld)


### PR DESCRIPTION
# Description

Corrects `rmp/v` to `rpm/V` in the `BLDCMotor` constructor comment.

No code behavior changed. This is a comment-only typo fix.

Related issue: none.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No runtime tests were run because this is a comment-only change.

Verified by reviewing the diff to confirm only the constructor comment was changed.

**Test Configuration/Setup**:
* Hardware: N/A
* IDE: N/A
* MCU package version: N/A