### PR TITLE
fix(teensy): use 12-bit ADC resolution for inline current sense

### DIFF
--- a/src/current_sense/hardware_specific/teensy/teensy_mcu.cpp
+++ b/src/current_sense/hardware_specific/teensy/teensy_mcu.cpp
@@ -3,7 +3,7 @@
 #if defined(__arm__) && defined(CORE_TEENSY)
 
 #define _ADC_VOLTAGE 3.3f
-#define _ADC_RESOLUTION 1024.0f
+#define _ADC_RESOLUTION 4096.0f
 
 // function reading an ADC value and returning the read voltage
 void* _configureADCInline(const void* driver_params, const int pinA,const int pinB,const int pinC){


### PR DESCRIPTION
## Summary
- Fix Teensy inline current sense ADC conversion constant to match 12-bit ADC reads (4096) instead of 10-bit (1024).

## Context
This matches Teensy `analogReadResolution(12)` behavior and prevents current measurements from being scaled incorrectly.

## Test plan
- [ ] Build example(s) on a Teensy target
- [ ] Verify current-sense readings scale correctly

Made with [Cursor](https://cursor.com)